### PR TITLE
Fixed IndexOutOfBoundsException when trying to update the sticky head…

### DIFF
--- a/sticky-headers/src/main/java/com/trading212/stickyheader/StickyHeaderDecoration.kt
+++ b/sticky-headers/src/main/java/com/trading212/stickyheader/StickyHeaderDecoration.kt
@@ -70,6 +70,8 @@ class StickyHeaderDecoration : RecyclerView.ItemDecoration() {
     fun clear() {
         stickyHeadersMap.clear()
         stickyOffsets.clear()
+        adapterPositionsMap.clear()
+        stickiesStack.clear()
     }
 
     override fun onDrawOver(canvas: Canvas, recyclerView: RecyclerView, state: RecyclerView.State) {
@@ -304,6 +306,8 @@ class StickyHeaderDecoration : RecyclerView.ItemDecoration() {
         }
 
         override fun onChanged() {
+
+            clear()
 
             updateStickyHeaders()
         }


### PR DESCRIPTION
Fixed IndexOutOfBoundsException when trying to update the sticky headers after a notifyDataSetChanged() call. The internal state of the decoration was not matching the adapter's state. Since we do not know what has changed after a notifyDataSetChanged() call, the easiest solution is to clear the decoration's internal state and wait for onDrawOver() calls to build the stickies from the latest adapter state.